### PR TITLE
Add Qt OpenGL STL viewer application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,67 @@
+cmake_minimum_required(VERSION 3.16)
+project(STLViewer LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+option(USE_ASSIMP "Build with Assimp for model loading" ON)
+
+find_package(Qt6 6.4 REQUIRED COMPONENTS Widgets OpenGL Gui)
+
+if(USE_ASSIMP)
+    find_package(assimp QUIET)
+    if(NOT assimp_FOUND)
+        message(WARNING "Assimp not found - falling back to internal STL parser")
+        set(USE_ASSIMP OFF)
+    endif()
+endif()
+
+set(SOURCES
+    src/main.cpp
+    src/MainWindow.cpp
+    src/GLViewport.cpp
+    src/Mesh.cpp
+    src/MeshLoader.cpp
+    src/STLParser.cpp
+    src/Camera.cpp
+    src/GridGizmo.cpp
+)
+
+set(HEADERS
+    src/MainWindow.h
+    src/GLViewport.h
+    src/Mesh.h
+    src/MeshLoader.h
+    src/STLParser.h
+    src/Camera.h
+    src/GridGizmo.h
+    src/MeshStatistics.h
+)
+
+add_executable(STLViewer
+    ${SOURCES}
+    ${HEADERS}
+)
+
+target_include_directories(STLViewer PRIVATE src)
+
+target_link_libraries(STLViewer
+    Qt6::Widgets
+    Qt6::Gui
+    Qt6::OpenGL
+)
+
+if(USE_ASSIMP AND assimp_FOUND)
+    target_compile_definitions(STLViewer PRIVATE USE_ASSIMP)
+    target_link_libraries(STLViewer PRIVATE assimp::assimp)
+endif()
+
+if (APPLE)
+    target_link_libraries(STLViewer PRIVATE "-framework Cocoa" "-framework IOKit" "-framework CoreVideo")
+endif()
+
+install(TARGETS STLViewer RUNTIME DESTINATION bin)
+install(DIRECTORY samples DESTINATION share)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,74 @@
-# testes
+# STL Viewer
+
+A cross-platform Qt 6 desktop application for exploring STL meshes with an interactive OpenGL viewport.
+
+## Features
+
+- Load ASCII and binary STL files via file dialog or drag & drop.
+- Optional Assimp integration (`-DUSE_ASSIMP=ON`) with robust fallback STL parser.
+- Orbit/pan/zoom camera with optional fly mode (WASD + QE, toggle with **F**).
+- Grid and axis gizmos, bounding box visualization, and detailed model metrics (bounds, triangle count, normals source).
+- Phong shaded, wireframe, or hybrid rendering with gamma correction and adjustable key light (RMB drag).
+- Backface culling toggle, per-face normal visualization, and optional vertex normal recomputation.
+- Per-model translate/rotate/scale controls with reset; units displayed in millimeters.
+- Screenshot capture to PNG, recent file history (last five), and persistent UI/settings between sessions.
+
+## Controls
+
+- **LMB drag** – Orbit camera around focus point.
+- **MMB drag** – Pan camera.
+- **Mouse wheel** – Zoom (dolly).
+- **RMB drag** – Adjust key light direction.
+- **F** – Toggle fly mode; use **WASD** to move, **Q/E** to descend/ascend (hold **Shift** to accelerate).
+- **Ctrl+O** – Open STL file.
+
+## Building
+
+### Prerequisites
+
+- CMake ≥ 3.16
+- C++20 compiler (MSVC 2019+, GCC 11+, or Clang 12+)
+- Qt 6.4+ (Widgets, OpenGL components)
+- Optional: Assimp (for extended format support)
+
+### Configure & Build
+
+```bash
+cmake -B build -S . -DUSE_ASSIMP=ON
+cmake --build build
+```
+
+The executable `STLViewer` will be located in `build/` (platform-specific subfolder).
+
+### Windows (MSVC)
+
+```powershell
+cmake -B build -S . -G "Visual Studio 17 2022" -A x64 -DUSE_ASSIMP=ON
+cmake --build build --config Release
+```
+
+### Linux (GCC or Clang)
+
+```bash
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DUSE_ASSIMP=ON
+cmake --build build
+```
+
+### macOS (Clang / Xcode)
+
+```bash
+cmake -B build -S . -G Xcode -DUSE_ASSIMP=ON
+cmake --build build --config Release
+```
+
+If Assimp is unavailable, the build automatically falls back to the internal STL parser (or specify `-DUSE_ASSIMP=OFF`).
+
+## Sample Assets
+
+Two small STL samples are included in the `samples/` folder (`pyramid_ascii.stl`, `tetra_binary.stl`) alongside an example screenshot (`resources/screenshot.png`).
+
+## Troubleshooting
+
+- Ensure Qt’s CMake configuration is discoverable (set `CMAKE_PREFIX_PATH` to your Qt installation if necessary).
+- When running on systems without OpenGL 4.1 core profile, adjust the requested version in `main.cpp`.
+- If STL files fail to load, check the message dialog for details; malformed files are handled gracefully.

--- a/samples/pyramid_ascii.stl
+++ b/samples/pyramid_ascii.stl
@@ -1,0 +1,37 @@
+solid pyramid
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0
+      vertex 50 0 0
+      vertex 25 50 0
+    endloop
+  endfacet
+  facet normal 0.707 0 0.707
+    outer loop
+      vertex 0 0 0
+      vertex 25 50 0
+      vertex 25 25 50
+    endloop
+  endfacet
+  facet normal -0.707 0 0.707
+    outer loop
+      vertex 50 0 0
+      vertex 25 25 50
+      vertex 25 50 0
+    endloop
+  endfacet
+  facet normal 0.0 -0.894 0.447
+    outer loop
+      vertex 0 0 0
+      vertex 25 25 50
+      vertex 50 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 25 50 0
+      vertex 50 0 0
+    endloop
+  endfacet
+endsolid pyramid

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -1,0 +1,115 @@
+#include "Camera.h"
+
+#include <QtMath>
+
+Camera::Camera() = default;
+
+void Camera::setPerspective(float fovY, float aspect, float nearPlane, float farPlane)
+{
+    m_fovY = fovY;
+    m_aspect = aspect;
+    m_nearPlane = nearPlane;
+    m_farPlane = farPlane;
+}
+
+void Camera::resize(int width, int height)
+{
+    if (height == 0)
+        height = 1;
+    m_aspect = static_cast<float>(width) / static_cast<float>(height);
+}
+
+void Camera::orbit(float deltaYawDeg, float deltaPitchDeg)
+{
+    m_yaw += deltaYawDeg;
+    m_pitch += deltaPitchDeg;
+    clampPitch();
+}
+
+void Camera::pan(const QVector2D &delta)
+{
+    QVector3D forward = (target() - position());
+    if (!forward.isNull())
+        forward.normalize();
+    QVector3D right = QVector3D::crossProduct(forward, QVector3D(0, 1, 0));
+    if (!right.isNull())
+        right.normalize();
+    QVector3D up = QVector3D::crossProduct(right, forward);
+    if (!up.isNull())
+        up.normalize();
+
+    m_target += (-right * delta.x() + up * delta.y());
+}
+
+void Camera::dolly(float delta)
+{
+    m_distance = qMax(1.0f, m_distance + delta);
+}
+
+void Camera::focus(const QVector3D &center, float radius)
+{
+    m_target = center;
+    m_distance = qMax(radius * 2.5f, 1.0f);
+}
+
+QMatrix4x4 Camera::viewMatrix() const
+{
+    QMatrix4x4 view;
+    QVector3D pos = position();
+    view.lookAt(pos, m_target, QVector3D(0, 1, 0));
+    return view;
+}
+
+QMatrix4x4 Camera::projectionMatrix() const
+{
+    QMatrix4x4 projection;
+    projection.perspective(m_fovY, m_aspect, m_nearPlane, m_farPlane);
+    return projection;
+}
+
+QVector3D Camera::position() const
+{
+    const float yawRad = qDegreesToRadians(m_yaw);
+    const float pitchRad = qDegreesToRadians(m_pitch);
+    QVector3D dir;
+    dir.setX(qCos(pitchRad) * qCos(yawRad));
+    dir.setY(qSin(pitchRad));
+    dir.setZ(qCos(pitchRad) * qSin(yawRad));
+    return m_target - dir.normalized() * m_distance;
+}
+
+void Camera::setTarget(const QVector3D &target)
+{
+    m_target = target;
+}
+
+void Camera::setDistance(float distance)
+{
+    m_distance = qMax(1.0f, distance);
+}
+
+void Camera::addFlyMovement(const QVector3D &movement)
+{
+    QVector3D pos = position();
+    QVector3D forward = (m_target - pos);
+    if (!forward.isNull())
+        forward.normalize();
+    QVector3D right = QVector3D::crossProduct(forward, QVector3D(0, 1, 0));
+    if (!right.isNull())
+        right.normalize();
+    QVector3D up = QVector3D::crossProduct(right, forward);
+    if (!up.isNull())
+        up.normalize();
+
+    QVector3D offset = right * movement.x() + up * movement.y() + forward * movement.z();
+    m_target += offset;
+}
+
+void Camera::clampPitch()
+{
+    const float limit = 89.0f;
+    if (m_pitch > limit)
+        m_pitch = limit;
+    if (m_pitch < -limit)
+        m_pitch = -limit;
+}

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <QMatrix4x4>
+#include <QVector2D>
+#include <QVector3D>
+
+class Camera
+{
+public:
+    Camera();
+
+    void setPerspective(float fovY, float aspect, float nearPlane, float farPlane);
+    void resize(int width, int height);
+
+    void orbit(float deltaYawDeg, float deltaPitchDeg);
+    void pan(const QVector2D &delta);
+    void dolly(float delta);
+
+    void focus(const QVector3D &center, float radius);
+
+    QMatrix4x4 viewMatrix() const;
+    QMatrix4x4 projectionMatrix() const;
+
+    QVector3D position() const;
+    QVector3D target() const { return m_target; }
+    float distance() const { return m_distance; }
+
+    void setTarget(const QVector3D &target);
+    void setDistance(float distance);
+
+    void enableFlyMode(bool enabled) { m_flyMode = enabled; }
+    bool flyMode() const { return m_flyMode; }
+
+    void addFlyMovement(const QVector3D &movement);
+
+private:
+    void clampPitch();
+
+    float m_yaw = -45.0f;
+    float m_pitch = -30.0f;
+    QVector3D m_target = QVector3D(0, 0, 0);
+    float m_distance = 250.0f;
+
+    float m_fovY = 45.0f;
+    float m_aspect = 1.0f;
+    float m_nearPlane = 1.0f;
+    float m_farPlane = 5000.0f;
+
+    bool m_flyMode = false;
+};

--- a/src/GLViewport.cpp
+++ b/src/GLViewport.cpp
@@ -1,0 +1,628 @@
+#include "GLViewport.h"
+
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include <QFileInfo>
+#include <QGuiApplication>
+#include <QImage>
+#include <QKeyEvent>
+#include <QMimeData>
+#include <QMouseEvent>
+#include <QVector2D>
+#include <QVector>
+#include <QUrl>
+#include <QWheelEvent>
+#include <QtMath>
+
+namespace
+{
+constexpr float kOrbitSpeed = 0.35f;
+constexpr float kPanSpeed = 0.2f;
+constexpr float kDollySpeed = 0.5f;
+constexpr float kFlySpeed = 150.0f;
+constexpr float kGamma = 2.2f;
+} // namespace
+
+GLViewport::GLViewport(QWidget *parent)
+    : QOpenGLWidget(parent)
+    , m_bboxVbo(QOpenGLBuffer::VertexBuffer)
+{
+    setFocusPolicy(Qt::StrongFocus);
+    setAcceptDrops(true);
+    updateLightDirection();
+    m_updateTimer.setInterval(16);
+    connect(&m_updateTimer, &QTimer::timeout, this, [this]() {
+        if (!m_elapsedTimer.isValid())
+            m_elapsedTimer.start();
+        const float deltaSeconds = m_elapsedTimer.restart() / 1000.0f;
+        handleFlyMode(deltaSeconds);
+        update();
+    });
+    m_updateTimer.start();
+    m_fpsTimer.start();
+}
+
+GLViewport::~GLViewport()
+{
+    makeCurrent();
+    m_bboxVbo.destroy();
+    m_bboxVao.destroy();
+    m_phongProgram.removeAllShaders();
+    m_colorProgram.removeAllShaders();
+    doneCurrent();
+}
+
+void GLViewport::initializeGL()
+{
+    initializeOpenGLFunctions();
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_MULTISAMPLE);
+    glClearColor(0.1f, 0.12f, 0.15f, 1.0f);
+
+    const char *phongVertex = R"(
+        #version 410 core
+        layout(location = 0) in vec3 aPosition;
+        layout(location = 1) in vec3 aNormal;
+        uniform mat4 uModel;
+        uniform mat4 uView;
+        uniform mat4 uProjection;
+        uniform mat3 uNormalMatrix;
+        out vec3 vNormal;
+        out vec3 vWorldPos;
+        void main() {
+            vec4 worldPos = uModel * vec4(aPosition, 1.0);
+            vWorldPos = worldPos.xyz;
+            vNormal = uNormalMatrix * aNormal;
+            gl_Position = uProjection * uView * worldPos;
+        }
+    )";
+
+    const char *phongFragment = R"(
+        #version 410 core
+        in vec3 vNormal;
+        in vec3 vWorldPos;
+        uniform vec3 uLightDirection;
+        uniform vec3 uCameraPos;
+        uniform vec3 uBaseColor;
+        uniform int uUseFaceNormals;
+        uniform float uGamma;
+        out vec4 fragColor;
+        void main() {
+            vec3 normal = normalize(vNormal);
+            if (uUseFaceNormals == 1) {
+                vec3 d1 = dFdx(vWorldPos);
+                vec3 d2 = dFdy(vWorldPos);
+                normal = normalize(cross(d1, d2));
+            }
+            vec3 lightDir = normalize(-uLightDirection);
+            float diff = max(dot(normal, lightDir), 0.0);
+            vec3 viewDir = normalize(uCameraPos - vWorldPos);
+            vec3 reflectDir = reflect(-lightDir, normal);
+            float spec = pow(max(dot(viewDir, reflectDir), 0.0), 32.0);
+            vec3 color = uBaseColor * (0.15 + diff) + vec3(0.4) * spec;
+            color = pow(max(color, vec3(0.0)), vec3(1.0 / max(uGamma, 0.0001)));
+            fragColor = vec4(color, 1.0);
+        }
+    )";
+
+    const char *colorVertex = R"(
+        #version 410 core
+        layout(location = 0) in vec3 aPosition;
+        uniform mat4 uMvp;
+        void main() {
+            gl_Position = uMvp * vec4(aPosition, 1.0);
+        }
+    )";
+
+    const char *colorFragment = R"(
+        #version 410 core
+        uniform vec3 uColor;
+        out vec4 fragColor;
+        void main() {
+            fragColor = vec4(uColor, 1.0);
+        }
+    )";
+
+    if (!m_phongProgram.addShaderFromSourceCode(QOpenGLShader::Vertex, phongVertex) ||
+        !m_phongProgram.addShaderFromSourceCode(QOpenGLShader::Fragment, phongFragment) ||
+        !m_phongProgram.link()) {
+        emit loadFailed(tr("Failed to compile Phong shader: %1").arg(m_phongProgram.log()));
+    }
+
+    if (!m_colorProgram.addShaderFromSourceCode(QOpenGLShader::Vertex, colorVertex) ||
+        !m_colorProgram.addShaderFromSourceCode(QOpenGLShader::Fragment, colorFragment) ||
+        !m_colorProgram.link()) {
+        emit loadFailed(tr("Failed to compile color shader: %1").arg(m_colorProgram.log()));
+    }
+
+    m_grid.initialize(this);
+    m_bboxVao.create();
+    m_bboxVbo.create();
+
+    m_camera.setPerspective(45.0f, static_cast<float>(width()) / qMax(1.0f, static_cast<float>(height())), 1.0f, 10000.0f);
+    emit cameraDistanceChanged(m_camera.distance());
+}
+
+void GLViewport::resizeGL(int w, int h)
+{
+    m_camera.resize(w, h);
+}
+
+void GLViewport::paintGL()
+{
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    if (m_backfaceCulling)
+        glEnable(GL_CULL_FACE);
+    else
+        glDisable(GL_CULL_FACE);
+
+    QMatrix4x4 model;
+    model.translate(m_translation);
+    model.rotate(m_rotation.x(), 1.0f, 0.0f, 0.0f);
+    model.rotate(m_rotation.y(), 0.0f, 1.0f, 0.0f);
+    model.rotate(m_rotation.z(), 0.0f, 0.0f, 1.0f);
+    model.scale(m_scale);
+
+    const QMatrix4x4 view = m_camera.viewMatrix();
+    const QMatrix4x4 projection = m_camera.projectionMatrix();
+
+    if (m_mesh.isValid() && m_phongProgram.isLinked()) {
+        if (m_shadingMode == ShadingMode::Shaded || m_shadingMode == ShadingMode::ShadedWireframe) {
+            m_phongProgram.bind();
+            updateCameraUniforms(m_phongProgram, model, view, projection);
+            m_phongProgram.setUniformValue("uLightDirection", m_lightDirection.normalized());
+            m_phongProgram.setUniformValue("uCameraPos", m_camera.position());
+            m_phongProgram.setUniformValue("uBaseColor", QVector3D(0.7f, 0.72f, 0.75f));
+            m_phongProgram.setUniformValue("uUseFaceNormals", m_faceNormals ? 1 : 0);
+            m_phongProgram.setUniformValue("uGamma", kGamma);
+            m_mesh.draw(this);
+            m_phongProgram.release();
+        }
+
+        if (m_shadingMode == ShadingMode::Wireframe || m_shadingMode == ShadingMode::ShadedWireframe) {
+            glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+            glDisable(GL_CULL_FACE);
+            m_colorProgram.bind();
+            m_colorProgram.setUniformValue("uMvp", projection * view * model);
+            m_colorProgram.setUniformValue("uColor", QVector3D(0.05f, 0.9f, 0.9f));
+            m_mesh.draw(this);
+            m_colorProgram.release();
+            glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+            if (m_backfaceCulling)
+                glEnable(GL_CULL_FACE);
+        }
+
+        if (m_shadingMode == ShadingMode::Shaded && m_backfaceCulling)
+            glEnable(GL_CULL_FACE);
+
+        if (m_bboxVertexCount > 0 && m_colorProgram.isLinked()) {
+            m_colorProgram.bind();
+            drawBoundingBox(projection * view * model, QVector3D(0.85f, 0.35f, 0.1f));
+            m_colorProgram.release();
+        }
+    }
+
+    if (m_gridVisible && m_colorProgram.isLinked()) {
+        m_colorProgram.bind();
+        QMatrix4x4 gridModel;
+        gridModel.setToIdentity();
+        m_colorProgram.setUniformValue("uMvp", projection * view * gridModel);
+        m_colorProgram.setUniformValue("uColor", QVector3D(0.3f, 0.3f, 0.3f));
+        m_grid.drawGrid(this);
+        m_colorProgram.release();
+    }
+
+    if (m_axesVisible && m_colorProgram.isLinked()) {
+        m_colorProgram.bind();
+        m_colorProgram.setUniformValue("uMvp", projection * view);
+        m_grid.drawAxes(this, [this](int axis) {
+            switch (axis) {
+            case 0:
+                m_colorProgram.setUniformValue("uColor", QVector3D(0.9f, 0.2f, 0.2f));
+                break;
+            case 1:
+                m_colorProgram.setUniformValue("uColor", QVector3D(0.2f, 0.9f, 0.2f));
+                break;
+            default:
+                m_colorProgram.setUniformValue("uColor", QVector3D(0.2f, 0.4f, 0.9f));
+                break;
+            }
+        });
+        m_colorProgram.release();
+    }
+
+    updateFps();
+}
+
+bool GLViewport::loadMesh(const QString &path, QString *errorMessage)
+{
+    MeshBuffer buffer = m_loader.load(path, errorMessage);
+    if (buffer.positions.isEmpty() || buffer.indices.isEmpty()) {
+        if (errorMessage && errorMessage->isEmpty())
+            *errorMessage = tr("No geometry found in %1").arg(path);
+        return false;
+    }
+
+    m_mesh.clear();
+    m_mesh.setData(buffer.positions, buffer.normals, buffer.indices, buffer.hasNormals);
+    if (m_recomputeNormals || !buffer.hasNormals)
+        m_mesh.computeSmoothNormals();
+    else
+        m_mesh.restoreOriginalNormals();
+
+    makeCurrent();
+    m_mesh.upload(this);
+    updateBoundingBoxBuffer();
+    doneCurrent();
+
+    updateStatistics(path);
+
+    const QVector3D center = (m_mesh.minBounds() + m_mesh.maxBounds()) * 0.5f;
+    const float radius = m_mesh.size().length() * 0.5f;
+    m_camera.focus(center, qMax(radius, 1.0f));
+    emit cameraDistanceChanged(m_camera.distance());
+
+    resetModelTransform();
+    update();
+    return true;
+}
+
+bool GLViewport::saveScreenshot(const QString &path)
+{
+    const QImage image = grabFramebuffer();
+    if (image.isNull())
+        return false;
+    return image.save(path, "PNG");
+}
+
+void GLViewport::setGridVisible(bool visible)
+{
+    if (m_gridVisible == visible)
+        return;
+    m_gridVisible = visible;
+    update();
+}
+
+void GLViewport::setAxesVisible(bool visible)
+{
+    if (m_axesVisible == visible)
+        return;
+    m_axesVisible = visible;
+    update();
+}
+
+void GLViewport::setBackfaceCullingEnabled(bool enabled)
+{
+    if (m_backfaceCulling == enabled)
+        return;
+    m_backfaceCulling = enabled;
+    update();
+}
+
+void GLViewport::setRecomputeNormals(bool enabled)
+{
+    if (m_recomputeNormals == enabled)
+        return;
+    m_recomputeNormals = enabled;
+    if (m_mesh.isValid()) {
+        if (enabled)
+            m_mesh.computeSmoothNormals();
+        else
+            m_mesh.restoreOriginalNormals();
+        makeCurrent();
+        m_mesh.upload(this);
+        doneCurrent();
+        updateStatistics(m_loadedFilePath);
+        update();
+    }
+}
+
+void GLViewport::setFaceNormalsEnabled(bool enabled)
+{
+    if (m_faceNormals == enabled)
+        return;
+    m_faceNormals = enabled;
+    update();
+}
+
+void GLViewport::setShadingMode(ShadingMode mode)
+{
+    if (m_shadingMode == mode)
+        return;
+    m_shadingMode = mode;
+    update();
+}
+
+void GLViewport::setModelTransform(const QVector3D &translation, const QVector3D &rotation, const QVector3D &scale)
+{
+    m_translation = translation;
+    m_rotation = rotation;
+    m_scale = QVector3D(qMax(scale.x(), 0.0001f), qMax(scale.y(), 0.0001f), qMax(scale.z(), 0.0001f));
+    syncTransformToUi();
+    update();
+}
+
+void GLViewport::resetModelTransform()
+{
+    m_translation = QVector3D(0, 0, 0);
+    m_rotation = QVector3D(0, 0, 0);
+    m_scale = QVector3D(1, 1, 1);
+    syncTransformToUi();
+    update();
+}
+
+void GLViewport::mousePressEvent(QMouseEvent *event)
+{
+    m_lastMousePos = event->pos();
+    if (event->button() == Qt::LeftButton)
+        m_leftButton = true;
+    if (event->button() == Qt::MiddleButton)
+        m_middleButton = true;
+    if (event->button() == Qt::RightButton)
+        m_rightButton = true;
+    setFocus();
+}
+
+void GLViewport::mouseMoveEvent(QMouseEvent *event)
+{
+    const QPoint delta = event->pos() - m_lastMousePos;
+    if (m_leftButton) {
+        m_camera.orbit(delta.x() * kOrbitSpeed, -delta.y() * kOrbitSpeed);
+        emit cameraDistanceChanged(m_camera.distance());
+    } else if (m_middleButton) {
+        const float distanceFactor = m_camera.distance() * 0.01f;
+        QVector2D panDelta(-delta.x() * kPanSpeed * distanceFactor, delta.y() * kPanSpeed * distanceFactor);
+        m_camera.pan(panDelta);
+    } else if (m_rightButton) {
+        m_lightAzimuth += delta.x() * 0.5f;
+        m_lightElevation = qBound(-89.0f, m_lightElevation - delta.y() * 0.5f, 89.0f);
+        updateLightDirection();
+    }
+    m_lastMousePos = event->pos();
+    update();
+}
+
+void GLViewport::mouseReleaseEvent(QMouseEvent *event)
+{
+    if (event->button() == Qt::LeftButton)
+        m_leftButton = false;
+    if (event->button() == Qt::MiddleButton)
+        m_middleButton = false;
+    if (event->button() == Qt::RightButton)
+        m_rightButton = false;
+}
+
+void GLViewport::wheelEvent(QWheelEvent *event)
+{
+    const float delta = static_cast<float>(event->angleDelta().y()) / 120.0f;
+    m_camera.dolly(-delta * kDollySpeed * m_camera.distance());
+    emit cameraDistanceChanged(m_camera.distance());
+    update();
+}
+
+void GLViewport::keyPressEvent(QKeyEvent *event)
+{
+    if (event->isAutoRepeat())
+        return;
+
+    switch (event->key()) {
+    case Qt::Key_W:
+        m_moveForward = true;
+        break;
+    case Qt::Key_S:
+        m_moveBackward = true;
+        break;
+    case Qt::Key_A:
+        m_moveLeft = true;
+        break;
+    case Qt::Key_D:
+        m_moveRight = true;
+        break;
+    case Qt::Key_Q:
+        m_moveDown = true;
+        break;
+    case Qt::Key_E:
+        m_moveUp = true;
+        break;
+    case Qt::Key_F:
+        m_flyMode = !m_flyMode;
+        break;
+    default:
+        break;
+    }
+}
+
+void GLViewport::keyReleaseEvent(QKeyEvent *event)
+{
+    if (event->isAutoRepeat())
+        return;
+
+    switch (event->key()) {
+    case Qt::Key_W:
+        m_moveForward = false;
+        break;
+    case Qt::Key_S:
+        m_moveBackward = false;
+        break;
+    case Qt::Key_A:
+        m_moveLeft = false;
+        break;
+    case Qt::Key_D:
+        m_moveRight = false;
+        break;
+    case Qt::Key_Q:
+        m_moveDown = false;
+        break;
+    case Qt::Key_E:
+        m_moveUp = false;
+        break;
+    default:
+        break;
+    }
+}
+
+void GLViewport::dragEnterEvent(QDragEnterEvent *event)
+{
+    if (event->mimeData()->hasUrls()) {
+        const QList<QUrl> urls = event->mimeData()->urls();
+        if (!urls.isEmpty()) {
+            const QString path = urls.first().toLocalFile();
+            if (path.endsWith(QLatin1String(".stl"), Qt::CaseInsensitive)) {
+                event->acceptProposedAction();
+                return;
+            }
+        }
+    }
+    event->ignore();
+}
+
+void GLViewport::dropEvent(QDropEvent *event)
+{
+    if (!event->mimeData()->hasUrls()) {
+        event->ignore();
+        return;
+    }
+    const QList<QUrl> urls = event->mimeData()->urls();
+    if (urls.isEmpty()) {
+        event->ignore();
+        return;
+    }
+    const QString path = urls.first().toLocalFile();
+    QString error;
+    if (!loadMesh(path, &error) && !error.isEmpty())
+        emit loadFailed(error);
+    event->acceptProposedAction();
+}
+
+void GLViewport::updateCameraUniforms(QOpenGLShaderProgram &program, const QMatrix4x4 &modelMatrix, const QMatrix4x4 &view, const QMatrix4x4 &projection)
+{
+    program.setUniformValue("uModel", modelMatrix);
+    program.setUniformValue("uView", view);
+    program.setUniformValue("uProjection", projection);
+    program.setUniformValue("uNormalMatrix", modelMatrix.normalMatrix());
+}
+
+void GLViewport::updateBoundingBoxBuffer()
+{
+    if (!m_mesh.isValid()) {
+        m_bboxVertexCount = 0;
+        return;
+    }
+
+    const QVector3D min = m_mesh.minBounds();
+    const QVector3D max = m_mesh.maxBounds();
+
+    QVector<QVector3D> vertices = {
+        {min.x(), min.y(), min.z()}, {max.x(), min.y(), min.z()},
+        {max.x(), min.y(), min.z()}, {max.x(), min.y(), max.z()},
+        {max.x(), min.y(), max.z()}, {min.x(), min.y(), max.z()},
+        {min.x(), min.y(), max.z()}, {min.x(), min.y(), min.z()},
+
+        {min.x(), max.y(), min.z()}, {max.x(), max.y(), min.z()},
+        {max.x(), max.y(), min.z()}, {max.x(), max.y(), max.z()},
+        {max.x(), max.y(), max.z()}, {min.x(), max.y(), max.z()},
+        {min.x(), max.y(), max.z()}, {min.x(), max.y(), min.z()},
+
+        {min.x(), min.y(), min.z()}, {min.x(), max.y(), min.z()},
+        {max.x(), min.y(), min.z()}, {max.x(), max.y(), min.z()},
+        {max.x(), min.y(), max.z()}, {max.x(), max.y(), max.z()},
+        {min.x(), min.y(), max.z()}, {min.x(), max.y(), max.z()}
+    };
+
+    m_bboxVertexCount = vertices.size();
+
+    if (!m_bboxVao.isCreated())
+        m_bboxVao.create();
+    QOpenGLVertexArrayObject::Binder vaoBinder(&m_bboxVao);
+
+    if (!m_bboxVbo.isCreated())
+        m_bboxVbo.create();
+    m_bboxVbo.bind();
+    m_bboxVbo.setUsagePattern(QOpenGLBuffer::DynamicDraw);
+    m_bboxVbo.allocate(vertices.constData(), vertices.size() * sizeof(QVector3D));
+
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(QVector3D), nullptr);
+}
+
+void GLViewport::drawBoundingBox(const QMatrix4x4 &mvp, const QVector3D &color)
+{
+    if (m_bboxVertexCount <= 0)
+        return;
+    QOpenGLVertexArrayObject::Binder vaoBinder(&m_bboxVao);
+    m_colorProgram.setUniformValue("uMvp", mvp);
+    m_colorProgram.setUniformValue("uColor", color);
+    glDrawArrays(GL_LINES, 0, m_bboxVertexCount);
+}
+
+void GLViewport::updateFps()
+{
+    ++m_frameCounter;
+    if (m_fpsTimer.elapsed() > 1000) {
+        const float fps = static_cast<float>(m_frameCounter) * 1000.0f / m_fpsTimer.elapsed();
+        emit fpsChanged(fps);
+        m_frameCounter = 0;
+        m_fpsTimer.restart();
+    }
+}
+
+void GLViewport::updateStatistics(const QString &filePath)
+{
+    m_loadedFilePath = filePath;
+    m_stats.fileName = QFileInfo(filePath).fileName();
+    m_stats.triangleCount = m_mesh.triangleCount();
+    m_stats.minBounds = m_mesh.minBounds();
+    m_stats.maxBounds = m_mesh.maxBounds();
+    m_stats.size = m_mesh.size();
+    m_stats.hasNormals = m_mesh.hasSourceNormals() && !m_recomputeNormals;
+    emit meshInfoChanged(m_stats);
+}
+
+void GLViewport::syncTransformToUi()
+{
+    emit transformChanged(m_translation, m_rotation, m_scale);
+}
+
+void GLViewport::handleFlyMode(float deltaSeconds)
+{
+    if (!m_flyMode)
+        return;
+
+    QVector3D direction;
+    if (m_moveForward)
+        direction.setZ(direction.z() + 1.0f);
+    if (m_moveBackward)
+        direction.setZ(direction.z() - 1.0f);
+    if (m_moveLeft)
+        direction.setX(direction.x() - 1.0f);
+    if (m_moveRight)
+        direction.setX(direction.x() + 1.0f);
+    if (m_moveUp)
+        direction.setY(direction.y() + 1.0f);
+    if (m_moveDown)
+        direction.setY(direction.y() - 1.0f);
+
+    if (direction.isNull())
+        return;
+
+    const Qt::KeyboardModifiers mods = QGuiApplication::keyboardModifiers();
+    float speed = kFlySpeed;
+    if (mods & Qt::ShiftModifier)
+        speed *= 2.5f;
+
+    direction.normalize();
+    m_camera.addFlyMovement(direction * speed * deltaSeconds);
+    emit cameraDistanceChanged(m_camera.distance());
+}
+
+void GLViewport::updateLightDirection()
+{
+    const float azimuthRad = qDegreesToRadians(m_lightAzimuth);
+    const float elevationRad = qDegreesToRadians(m_lightElevation);
+    m_lightDirection.setX(qCos(elevationRad) * qCos(azimuthRad));
+    m_lightDirection.setY(qSin(elevationRad));
+    m_lightDirection.setZ(qCos(elevationRad) * qSin(azimuthRad));
+    if (m_lightDirection.isNull())
+        m_lightDirection = QVector3D(0.0f, -1.0f, 0.0f);
+}

--- a/src/GLViewport.h
+++ b/src/GLViewport.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "Camera.h"
+#include "GridGizmo.h"
+#include "Mesh.h"
+#include "MeshLoader.h"
+#include "MeshStatistics.h"
+
+#include <QElapsedTimer>
+#include <QMatrix4x4>
+#include <QOpenGLBuffer>
+#include <QOpenGLShaderProgram>
+#include <QOpenGLVertexArrayObject>
+#include <QOpenGLWidget>
+#include <QPointer>
+#include <QTimer>
+
+class GLViewport : public QOpenGLWidget, protected QOpenGLFunctions_4_1_Core
+{
+    Q_OBJECT
+
+public:
+    enum class ShadingMode
+    {
+        Shaded = 0,
+        Wireframe,
+        ShadedWireframe
+    };
+
+    explicit GLViewport(QWidget *parent = nullptr);
+    ~GLViewport() override;
+
+    bool loadMesh(const QString &path, QString *errorMessage);
+    bool saveScreenshot(const QString &path);
+
+    void setGridVisible(bool visible);
+    void setAxesVisible(bool visible);
+    void setBackfaceCullingEnabled(bool enabled);
+    void setRecomputeNormals(bool enabled);
+    void setFaceNormalsEnabled(bool enabled);
+    void setShadingMode(ShadingMode mode);
+
+    void setModelTransform(const QVector3D &translation, const QVector3D &rotation, const QVector3D &scale);
+    void resetModelTransform();
+
+signals:
+    void meshInfoChanged(const MeshStatistics &stats);
+    void loadFailed(const QString &message);
+    void cameraDistanceChanged(float distance);
+    void fpsChanged(float fps);
+    void transformChanged(const QVector3D &translation, const QVector3D &rotation, const QVector3D &scale);
+
+protected:
+    void initializeGL() override;
+    void resizeGL(int w, int h) override;
+    void paintGL() override;
+
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void wheelEvent(QWheelEvent *event) override;
+    void keyPressEvent(QKeyEvent *event) override;
+    void keyReleaseEvent(QKeyEvent *event) override;
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
+
+private:
+    void updateCameraUniforms(QOpenGLShaderProgram &program, const QMatrix4x4 &modelMatrix, const QMatrix4x4 &view, const QMatrix4x4 &projection);
+    void updateBoundingBoxBuffer();
+    void drawBoundingBox(const QMatrix4x4 &mvp, const QVector3D &color);
+    void updateFps();
+    void updateStatistics(const QString &filePath);
+    void syncTransformToUi();
+    void handleFlyMode(float deltaSeconds);
+    void updateLightDirection();
+
+    MeshLoader m_loader;
+    Mesh m_mesh;
+    MeshStatistics m_stats;
+    QString m_loadedFilePath;
+
+    Camera m_camera;
+    GridGizmo m_grid;
+
+    bool m_gridVisible = true;
+    bool m_axesVisible = true;
+    bool m_backfaceCulling = false;
+    bool m_recomputeNormals = false;
+    bool m_faceNormals = false;
+    ShadingMode m_shadingMode = ShadingMode::Shaded;
+
+    QVector3D m_translation = QVector3D(0, 0, 0);
+    QVector3D m_rotation = QVector3D(0, 0, 0);
+    QVector3D m_scale = QVector3D(1, 1, 1);
+
+    QOpenGLShaderProgram m_phongProgram;
+    QOpenGLShaderProgram m_colorProgram;
+
+    QOpenGLBuffer m_bboxVbo;
+    QOpenGLVertexArrayObject m_bboxVao;
+    int m_bboxVertexCount = 0;
+
+    QTimer m_updateTimer;
+    QElapsedTimer m_elapsedTimer;
+    QElapsedTimer m_fpsTimer;
+    int m_frameCounter = 0;
+
+    QPoint m_lastMousePos;
+    bool m_leftButton = false;
+    bool m_middleButton = false;
+    bool m_rightButton = false;
+
+    bool m_flyMode = false;
+    QVector3D m_flyVelocity;
+    bool m_moveForward = false;
+    bool m_moveBackward = false;
+    bool m_moveLeft = false;
+    bool m_moveRight = false;
+    bool m_moveUp = false;
+    bool m_moveDown = false;
+
+    QVector3D m_lightDirection = QVector3D(-0.4f, -1.0f, -0.6f);
+    float m_lightAzimuth = -45.0f;
+    float m_lightElevation = -35.0f;
+};

--- a/src/GridGizmo.cpp
+++ b/src/GridGizmo.cpp
@@ -1,0 +1,106 @@
+#include "GridGizmo.h"
+
+#include <QVector3D>
+
+GridGizmo::GridGizmo()
+    : m_gridVbo(QOpenGLBuffer::VertexBuffer)
+    , m_axesVbo(QOpenGLBuffer::VertexBuffer)
+{
+}
+
+GridGizmo::~GridGizmo()
+{
+    if (m_gridVbo.isCreated())
+        m_gridVbo.destroy();
+    if (m_axesVbo.isCreated())
+        m_axesVbo.destroy();
+    if (m_gridVao.isCreated())
+        m_gridVao.destroy();
+    if (m_axesVao.isCreated())
+        m_axesVao.destroy();
+}
+
+void GridGizmo::initialize(QOpenGLFunctions_4_1_Core *gl)
+{
+    if (m_initialized || !gl)
+        return;
+
+    createGridGeometry(gl);
+    createAxesGeometry(gl);
+    m_initialized = true;
+}
+
+void GridGizmo::createGridGeometry(QOpenGLFunctions_4_1_Core *gl)
+{
+    if (!m_gridVao.isCreated())
+        m_gridVao.create();
+    QOpenGLVertexArrayObject::Binder vaoBinder(&m_gridVao);
+
+    if (!m_gridVbo.isCreated())
+        m_gridVbo.create();
+    m_gridVbo.bind();
+    m_gridVbo.setUsagePattern(QOpenGLBuffer::StaticDraw);
+
+    const int divisions = 20;
+    const float spacing = 10.0f;
+    const float halfSize = divisions * spacing * 0.5f;
+    QVector<QVector3D> vertices;
+    vertices.reserve((divisions + 1) * 4);
+    for (int i = 0; i <= divisions; ++i) {
+        float offset = -halfSize + i * spacing;
+        vertices.append(QVector3D(offset, 0.0f, -halfSize));
+        vertices.append(QVector3D(offset, 0.0f, halfSize));
+        vertices.append(QVector3D(-halfSize, 0.0f, offset));
+        vertices.append(QVector3D(halfSize, 0.0f, offset));
+    }
+    m_gridVertexCount = vertices.size();
+    m_gridVbo.allocate(vertices.constData(), vertices.size() * sizeof(QVector3D));
+
+    gl->glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(QVector3D), nullptr);
+    gl->glEnableVertexAttribArray(0);
+}
+
+void GridGizmo::createAxesGeometry(QOpenGLFunctions_4_1_Core *gl)
+{
+    if (!m_axesVao.isCreated())
+        m_axesVao.create();
+    QOpenGLVertexArrayObject::Binder vaoBinder(&m_axesVao);
+
+    if (!m_axesVbo.isCreated())
+        m_axesVbo.create();
+    m_axesVbo.bind();
+    m_axesVbo.setUsagePattern(QOpenGLBuffer::StaticDraw);
+
+    const float axisLength = 100.0f;
+    QVector<QVector3D> vertices = {
+        QVector3D(0.0f, 0.0f, 0.0f), QVector3D(axisLength, 0.0f, 0.0f), // X
+        QVector3D(0.0f, 0.0f, 0.0f), QVector3D(0.0f, axisLength, 0.0f), // Y
+        QVector3D(0.0f, 0.0f, 0.0f), QVector3D(0.0f, 0.0f, axisLength)  // Z
+    };
+
+    m_axesVertexCount = vertices.size();
+    m_axesVbo.allocate(vertices.constData(), vertices.size() * sizeof(QVector3D));
+
+    gl->glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(QVector3D), nullptr);
+    gl->glEnableVertexAttribArray(0);
+}
+
+void GridGizmo::drawGrid(QOpenGLFunctions_4_1_Core *gl)
+{
+    if (!m_initialized || !gl)
+        return;
+    QOpenGLVertexArrayObject::Binder vaoBinder(&m_gridVao);
+    gl->glDrawArrays(GL_LINES, 0, m_gridVertexCount);
+}
+
+void GridGizmo::drawAxes(QOpenGLFunctions_4_1_Core *gl, const std::function<void(int axis)> &configureDraw)
+{
+    if (!m_initialized || !gl)
+        return;
+    QOpenGLVertexArrayObject::Binder vaoBinder(&m_axesVao);
+    for (int axis = 0; axis < 3; ++axis) {
+        if (configureDraw)
+            configureDraw(axis);
+        gl->glDrawArrays(GL_LINES, axis * 2, 2);
+    }
+}

--- a/src/GridGizmo.h
+++ b/src/GridGizmo.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <QOpenGLBuffer>
+#include <QOpenGLFunctions_4_1_Core>
+#include <QOpenGLVertexArrayObject>
+#include <functional>
+
+class GridGizmo
+{
+public:
+    GridGizmo();
+    ~GridGizmo();
+
+    void initialize(QOpenGLFunctions_4_1_Core *gl);
+    void drawGrid(QOpenGLFunctions_4_1_Core *gl);
+    void drawAxes(QOpenGLFunctions_4_1_Core *gl, const std::function<void(int axis)> &configureDraw);
+
+private:
+    void createGridGeometry(QOpenGLFunctions_4_1_Core *gl);
+    void createAxesGeometry(QOpenGLFunctions_4_1_Core *gl);
+
+    QOpenGLVertexArrayObject m_gridVao;
+    QOpenGLBuffer m_gridVbo;
+    int m_gridVertexCount = 0;
+
+    QOpenGLVertexArrayObject m_axesVao;
+    QOpenGLBuffer m_axesVbo;
+    int m_axesVertexCount = 0;
+
+    bool m_initialized = false;
+};

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1,0 +1,428 @@
+#include "MainWindow.h"
+#include "GLViewport.h"
+
+#include <QAction>
+#include <QAbstractItemView>
+#include <QApplication>
+#include <QCheckBox>
+#include <QCloseEvent>
+#include <QComboBox>
+#include <QDir>
+#include <QDockWidget>
+#include <QDoubleSpinBox>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QFormLayout>
+#include <QLabel>
+#include <QLayout>
+#include <QListWidget>
+#include <QMenuBar>
+#include <QMessageBox>
+#include <QProgressDialog>
+#include <QPushButton>
+#include <QSettings>
+#include <QStatusBar>
+#include <QStringList>
+#include <QToolBar>
+#include <QVBoxLayout>
+#include <QObject>
+
+namespace
+{
+constexpr int kMaxRecentFiles = 5;
+
+QDoubleSpinBox *createSpinBox(double min, double max, double step)
+{
+    auto *spin = new QDoubleSpinBox;
+    spin->setRange(min, max);
+    spin->setDecimals(3);
+    spin->setSingleStep(step);
+    spin->setAlignment(Qt::AlignRight);
+    return spin;
+}
+
+} // namespace
+
+MainWindow::MainWindow(QWidget *parent)
+    : QMainWindow(parent)
+{
+    createUi();
+    readSettings();
+    populateRecentFiles();
+    statusBar()->showMessage(tr("LMB orbit • MMB pan • Wheel zoom • F toggles fly mode"));
+}
+
+MainWindow::~MainWindow()
+{
+    writeSettings();
+}
+
+void MainWindow::createUi()
+{
+    setWindowTitle(tr("STL Viewer"));
+    resize(1280, 800);
+
+    m_viewport = new GLViewport(this);
+    setCentralWidget(m_viewport);
+
+    createDock();
+    createMenus();
+
+    m_statusCameraLabel = new QLabel(tr("Dist: --"));
+    m_statusFpsLabel = new QLabel(tr("FPS: --"));
+    statusBar()->addPermanentWidget(m_statusCameraLabel);
+    statusBar()->addPermanentWidget(m_statusFpsLabel);
+
+    connect(m_viewport, &GLViewport::meshInfoChanged, this, &MainWindow::updateMeshInfo);
+    connect(m_viewport, &GLViewport::cameraDistanceChanged, this, &MainWindow::updateCameraStatus);
+    connect(m_viewport, &GLViewport::fpsChanged, this, &MainWindow::updateFps);
+    connect(m_viewport, &GLViewport::loadFailed, this, &MainWindow::handleLoadFailure);
+    connect(m_viewport, &GLViewport::transformChanged, this, [this](const QVector3D &t, const QVector3D &r, const QVector3D &s) {
+        m_ignoreTransformSignal = true;
+        for (int i = 0; i < 3; ++i) {
+            if (m_translate[i])
+                m_translate[i]->setValue(t[i]);
+            if (m_rotate[i])
+                m_rotate[i]->setValue(r[i]);
+            if (m_scale[i])
+                m_scale[i]->setValue(s[i]);
+        }
+        m_ignoreTransformSignal = false;
+    });
+}
+
+void MainWindow::createDock()
+{
+    m_sidebar = new QDockWidget(tr("Controls"), this);
+    m_sidebar->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
+
+    auto *panel = new QWidget;
+    auto *layout = new QVBoxLayout(panel);
+    layout->setContentsMargins(8, 8, 8, 8);
+    layout->setSpacing(6);
+
+    auto *openButton = new QPushButton(tr("Open STL…"));
+    connect(openButton, &QPushButton::clicked, this, &MainWindow::openFileDialog);
+    layout->addWidget(openButton);
+
+    m_recentList = new QListWidget;
+    m_recentList->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_recentList->setMaximumHeight(110);
+    layout->addWidget(m_recentList);
+    connect(m_recentList, &QListWidget::itemActivated, this, [this](QListWidgetItem *item) {
+        if (item)
+            loadFile(item->data(Qt::UserRole).toString());
+    });
+
+    m_infoLabel = new QLabel(tr("No model loaded"));
+    m_infoLabel->setWordWrap(true);
+    m_infoLabel->setTextFormat(Qt::RichText);
+    layout->addWidget(m_infoLabel);
+
+    auto *renderLabel = new QLabel(tr("Render Settings"));
+    renderLabel->setStyleSheet("font-weight: bold");
+    layout->addWidget(renderLabel);
+
+    m_gridCheck = new QCheckBox(tr("Show Grid"));
+    m_axisCheck = new QCheckBox(tr("Show Axes"));
+    m_cullingCheck = new QCheckBox(tr("Backface Culling"));
+    m_normalsCheck = new QCheckBox(tr("Recompute Vertex Normals"));
+    m_faceNormalCheck = new QCheckBox(tr("Use Face Normals"));
+
+    for (QCheckBox *box : {m_gridCheck, m_axisCheck, m_cullingCheck, m_normalsCheck, m_faceNormalCheck}) {
+        layout->addWidget(box);
+        connect(box, &QCheckBox::toggled, this, &MainWindow::applyRenderToggles);
+    }
+
+    m_shadingCombo = new QComboBox;
+    m_shadingCombo->addItems({tr("Shaded"), tr("Wireframe"), tr("Shaded + Wireframe")});
+    layout->addWidget(m_shadingCombo);
+    connect(m_shadingCombo, qOverload<int>(&QComboBox::currentIndexChanged), this, &MainWindow::toggleShadingMode);
+
+    auto *transformLabel = new QLabel(tr("Transform"));
+    transformLabel->setStyleSheet("font-weight: bold");
+    layout->addWidget(transformLabel);
+
+    auto *transformWidget = new QWidget;
+    auto *form = new QFormLayout(transformWidget);
+    form->setLabelAlignment(Qt::AlignLeft);
+
+    const QString axes[3] = {tr("X"), tr("Y"), tr("Z")};
+    for (int i = 0; i < 3; ++i) {
+        m_translate[i] = createSpinBox(-1000.0, 1000.0, 1.0);
+        form->addRow(tr("T%1 (mm)").arg(axes[i]), m_translate[i]);
+        connect(m_translate[i], qOverload<double>(&QDoubleSpinBox::valueChanged), this, &MainWindow::updateTransformFromUi);
+    }
+    for (int i = 0; i < 3; ++i) {
+        m_rotate[i] = createSpinBox(-720.0, 720.0, 1.0);
+        form->addRow(tr("R%1 (°)").arg(axes[i]), m_rotate[i]);
+        connect(m_rotate[i], qOverload<double>(&QDoubleSpinBox::valueChanged), this, &MainWindow::updateTransformFromUi);
+    }
+    for (int i = 0; i < 3; ++i) {
+        m_scale[i] = createSpinBox(0.001, 1000.0, 0.01);
+        m_scale[i]->setValue(1.0);
+        form->addRow(tr("S%1").arg(axes[i]), m_scale[i]);
+        connect(m_scale[i], qOverload<double>(&QDoubleSpinBox::valueChanged), this, &MainWindow::updateTransformFromUi);
+    }
+
+    layout->addWidget(transformWidget);
+
+    auto *resetButton = new QPushButton(tr("Reset Transform"));
+    layout->addWidget(resetButton);
+    connect(resetButton, &QPushButton::clicked, this, &MainWindow::resetTransform);
+
+    layout->addStretch(1);
+
+    m_sidebar->setWidget(panel);
+    addDockWidget(Qt::LeftDockWidgetArea, m_sidebar);
+}
+
+void MainWindow::createMenus()
+{
+    auto *fileMenu = menuBar()->addMenu(tr("&File"));
+
+    m_openAction = fileMenu->addAction(tr("&Open…"), this, &MainWindow::openFileDialog, QKeySequence::Open);
+    m_recentMenu = fileMenu->addMenu(tr("Recent Files"));
+    for (int i = 0; i < kMaxRecentFiles; ++i) {
+        auto *action = new QAction(this);
+        action->setVisible(false);
+        connect(action, &QAction::triggered, this, &MainWindow::openRecentFile);
+        m_recentMenu->addAction(action);
+        m_recentFileActions.append(action);
+    }
+    fileMenu->addSeparator();
+
+    m_screenshotAction = fileMenu->addAction(tr("Save Screenshot"), this, &MainWindow::saveScreenshot);
+
+    fileMenu->addSeparator();
+    fileMenu->addAction(tr("E&xit"), this, &QWidget::close, QKeySequence::Quit);
+}
+
+void MainWindow::openFileDialog()
+{
+    QSettings settings;
+    const QString dir = settings.value("lastDirectory", QDir::homePath()).toString();
+    const QString path = QFileDialog::getOpenFileName(this, tr("Open STL"), dir, tr("STL Files (*.stl)"));
+    if (path.isEmpty())
+        return;
+
+    settings.setValue("lastDirectory", QFileInfo(path).absolutePath());
+    loadFile(path);
+}
+
+void MainWindow::openRecentFile()
+{
+    auto *action = qobject_cast<QAction *>(sender());
+    if (!action)
+        return;
+    const QString path = action->data().toString();
+    loadFile(path);
+}
+
+void MainWindow::loadFile(const QString &path)
+{
+    if (path.isEmpty())
+        return;
+
+    QProgressDialog progress(tr("Loading %1").arg(QFileInfo(path).fileName()), tr("Cancel"), 0, 0, this);
+    progress.setWindowModality(Qt::ApplicationModal);
+    progress.setAutoClose(true);
+    progress.setCancelButton(nullptr);
+    progress.show();
+    QApplication::processEvents();
+
+    QString errorMessage;
+    if (!m_viewport->loadMesh(path, &errorMessage)) {
+        progress.close();
+        if (!errorMessage.isEmpty())
+            handleLoadFailure(errorMessage);
+        return;
+    }
+
+    progress.close();
+    setWindowFilePath(path);
+    m_currentFilePath = path;
+    addRecentFile(path);
+    refreshModelDetails();
+}
+
+void MainWindow::updateMeshInfo(const MeshStatistics &stats)
+{
+    m_currentStats = stats;
+    refreshModelDetails();
+}
+
+void MainWindow::refreshModelDetails()
+{
+    if (m_currentStats.fileName.isEmpty()) {
+        m_infoLabel->setText(tr("No model loaded"));
+        return;
+    }
+
+    const QVector3D min = m_currentStats.minBounds;
+    const QVector3D max = m_currentStats.maxBounds;
+    const QVector3D size = m_currentStats.size;
+
+    const QString info = tr(
+        "<b>%1</b><br/>Triangles: %2<br/>Bounds min: (%3, %4, %5) mm<br/>Bounds max: (%6, %7, %8) mm<br/>Size: (%9, %10, %11) mm<br/>Normals: %12")
+                              .arg(m_currentStats.fileName.toHtmlEscaped())
+                              .arg(QString::number(m_currentStats.triangleCount))
+                              .arg(QString::number(min.x(), 'f', 2))
+                              .arg(QString::number(min.y(), 'f', 2))
+                              .arg(QString::number(min.z(), 'f', 2))
+                              .arg(QString::number(max.x(), 'f', 2))
+                              .arg(QString::number(max.y(), 'f', 2))
+                              .arg(QString::number(max.z(), 'f', 2))
+                              .arg(QString::number(size.x(), 'f', 2))
+                              .arg(QString::number(size.y(), 'f', 2))
+                              .arg(QString::number(size.z(), 'f', 2))
+                              .arg(m_currentStats.hasNormals ? tr("Provided") : tr("Generated"));
+
+    m_infoLabel->setText(info);
+}
+
+void MainWindow::updateCameraStatus(float distance)
+{
+    if (!m_statusCameraLabel)
+        return;
+    m_statusCameraLabel->setText(tr("Dist: %1 mm").arg(distance, 0, 'f', 2));
+}
+
+void MainWindow::updateFps(float fps)
+{
+    if (!m_statusFpsLabel)
+        return;
+    m_statusFpsLabel->setText(tr("FPS: %1").arg(fps, 0, 'f', 1));
+}
+
+void MainWindow::handleLoadFailure(const QString &message)
+{
+    QMessageBox::critical(this, tr("Failed to load STL"), message);
+}
+
+void MainWindow::saveScreenshot()
+{
+    const QString path = QFileDialog::getSaveFileName(this, tr("Save Screenshot"), QString(), tr("PNG Image (*.png)"));
+    if (path.isEmpty())
+        return;
+    if (!m_viewport->saveScreenshot(path)) {
+        QMessageBox::warning(this, tr("Screenshot"), tr("Failed to save screenshot."));
+    }
+}
+
+void MainWindow::updateTransformFromUi()
+{
+    if (m_ignoreTransformSignal)
+        return;
+
+    QVector3D t, r, s;
+    for (int i = 0; i < 3; ++i) {
+        t[i] = m_translate[i] ? static_cast<float>(m_translate[i]->value()) : 0.0f;
+        r[i] = m_rotate[i] ? static_cast<float>(m_rotate[i]->value()) : 0.0f;
+        s[i] = m_scale[i] ? static_cast<float>(m_scale[i]->value()) : 1.0f;
+    }
+    m_viewport->setModelTransform(t, r, s);
+}
+
+void MainWindow::resetTransform()
+{
+    m_viewport->resetModelTransform();
+}
+
+void MainWindow::toggleShadingMode(int index)
+{
+    m_viewport->setShadingMode(static_cast<GLViewport::ShadingMode>(index));
+}
+
+void MainWindow::applyRenderToggles()
+{
+    if (!m_viewport)
+        return;
+    m_viewport->setGridVisible(m_gridCheck->isChecked());
+    m_viewport->setAxesVisible(m_axisCheck->isChecked());
+    m_viewport->setBackfaceCullingEnabled(m_cullingCheck->isChecked());
+    m_viewport->setRecomputeNormals(m_normalsCheck->isChecked());
+    m_viewport->setFaceNormalsEnabled(m_faceNormalCheck->isChecked());
+}
+
+void MainWindow::populateRecentFiles()
+{
+    const QStringList files = recentFiles();
+    for (int i = 0; i < m_recentFileActions.size(); ++i) {
+        if (i < files.size()) {
+            const QString text = QFileInfo(files.at(i)).fileName();
+            m_recentFileActions[i]->setText(tr("%1 %2").arg(i + 1).arg(text));
+            m_recentFileActions[i]->setData(files.at(i));
+            m_recentFileActions[i]->setVisible(true);
+        } else {
+            m_recentFileActions[i]->setVisible(false);
+        }
+    }
+
+    if (m_recentList) {
+        m_recentList->clear();
+        for (const QString &file : files) {
+            auto *item = new QListWidgetItem(QFileInfo(file).fileName());
+            item->setToolTip(file);
+            item->setData(Qt::UserRole, file);
+            m_recentList->addItem(item);
+        }
+    }
+}
+
+void MainWindow::addRecentFile(const QString &path)
+{
+    QStringList files = recentFiles();
+    files.removeAll(path);
+    files.prepend(path);
+    while (files.size() > kMaxRecentFiles)
+        files.removeLast();
+    setRecentFiles(files);
+    populateRecentFiles();
+}
+
+QStringList MainWindow::recentFiles() const
+{
+    QSettings settings;
+    return settings.value("recentFiles").toStringList();
+}
+
+void MainWindow::setRecentFiles(const QStringList &paths)
+{
+    QSettings settings;
+    settings.setValue("recentFiles", paths);
+}
+
+void MainWindow::readSettings()
+{
+    QSettings settings;
+    restoreGeometry(settings.value("geometry").toByteArray());
+    restoreState(settings.value("windowState").toByteArray());
+
+    m_gridCheck->setChecked(settings.value("render/showGrid", true).toBool());
+    m_axisCheck->setChecked(settings.value("render/showAxes", true).toBool());
+    m_cullingCheck->setChecked(settings.value("render/backfaceCulling", false).toBool());
+    m_normalsCheck->setChecked(settings.value("render/recomputeNormals", false).toBool());
+    m_faceNormalCheck->setChecked(settings.value("render/faceNormals", false).toBool());
+    m_shadingCombo->setCurrentIndex(settings.value("render/shadingMode", 0).toInt());
+    applyRenderToggles();
+}
+
+void MainWindow::writeSettings()
+{
+    QSettings settings;
+    settings.setValue("geometry", saveGeometry());
+    settings.setValue("windowState", saveState());
+    settings.setValue("render/showGrid", m_gridCheck->isChecked());
+    settings.setValue("render/showAxes", m_axisCheck->isChecked());
+    settings.setValue("render/backfaceCulling", m_cullingCheck->isChecked());
+    settings.setValue("render/recomputeNormals", m_normalsCheck->isChecked());
+    settings.setValue("render/faceNormals", m_faceNormalCheck->isChecked());
+    settings.setValue("render/shadingMode", m_shadingCombo->currentIndex());
+}
+
+void MainWindow::closeEvent(QCloseEvent *event)
+{
+    writeSettings();
+    QMainWindow::closeEvent(event);
+}

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <QMainWindow>
+#include <QPointer>
+#include <QVector3D>
+
+#include "MeshStatistics.h"
+
+class QAction;
+class QLabel;
+class QListWidget;
+class QDoubleSpinBox;
+class QDockWidget;
+class QMenu;
+class QPushButton;
+class QCheckBox;
+class QComboBox;
+class QSettings;
+class QListWidget;
+
+class GLViewport;
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+
+public:
+    explicit MainWindow(QWidget *parent = nullptr);
+    ~MainWindow() override;
+
+protected:
+    void closeEvent(QCloseEvent *event) override;
+
+private slots:
+    void openFileDialog();
+    void openRecentFile();
+    void updateMeshInfo(const MeshStatistics &stats);
+    void updateCameraStatus(float distance);
+    void updateFps(float fps);
+    void handleLoadFailure(const QString &message);
+    void saveScreenshot();
+    void updateTransformFromUi();
+    void resetTransform();
+    void toggleShadingMode(int index);
+    void applyRenderToggles();
+
+private:
+    void createUi();
+    void createDock();
+    void createMenus();
+    void populateRecentFiles();
+    void addRecentFile(const QString &path);
+    QStringList recentFiles() const;
+    void setRecentFiles(const QStringList &paths);
+    void loadFile(const QString &path);
+    void readSettings();
+    void writeSettings();
+    void refreshModelDetails();
+
+    GLViewport *m_viewport = nullptr;
+    QDockWidget *m_sidebar = nullptr;
+
+    QAction *m_openAction = nullptr;
+    QAction *m_screenshotAction = nullptr;
+    QMenu *m_recentMenu = nullptr;
+    QList<QAction *> m_recentFileActions;
+    QListWidget *m_recentList = nullptr;
+
+    QLabel *m_infoLabel = nullptr;
+    QLabel *m_statusCameraLabel = nullptr;
+    QLabel *m_statusFpsLabel = nullptr;
+
+    QCheckBox *m_gridCheck = nullptr;
+    QCheckBox *m_axisCheck = nullptr;
+    QCheckBox *m_cullingCheck = nullptr;
+    QCheckBox *m_normalsCheck = nullptr;
+    QCheckBox *m_faceNormalCheck = nullptr;
+
+    QComboBox *m_shadingCombo = nullptr;
+
+    QDoubleSpinBox *m_translate[3] = {nullptr, nullptr, nullptr};
+    QDoubleSpinBox *m_rotate[3] = {nullptr, nullptr, nullptr};
+    QDoubleSpinBox *m_scale[3] = {nullptr, nullptr, nullptr};
+
+    MeshStatistics m_currentStats;
+    QString m_currentFilePath;
+
+    bool m_ignoreTransformSignal = false;
+};

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -1,0 +1,185 @@
+#include "Mesh.h"
+
+#include <QtMath>
+#include <algorithm>
+
+Mesh::Mesh()
+    : m_vbo(QOpenGLBuffer::VertexBuffer)
+    , m_ebo(QOpenGLBuffer::IndexBuffer)
+{
+}
+
+Mesh::~Mesh()
+{
+    clear();
+}
+
+void Mesh::clear()
+{
+    m_positions.clear();
+    m_indices.clear();
+    m_normals.clear();
+    m_originalNormals.clear();
+    m_hasSourceNormals = false;
+    m_uploaded = false;
+
+    if (m_vao.isCreated())
+        m_vao.destroy();
+    if (m_vbo.isCreated())
+        m_vbo.destroy();
+    if (m_ebo.isCreated())
+        m_ebo.destroy();
+}
+
+bool Mesh::isValid() const
+{
+    return !m_positions.isEmpty() && !m_indices.isEmpty();
+}
+
+void Mesh::setData(const QVector<QVector3D> &positions,
+                   const QVector<QVector3D> &normals,
+                   const QVector<unsigned int> &indices,
+                   bool hasNormals)
+{
+    m_positions = positions;
+    m_indices = indices;
+    m_originalNormals = normals;
+    m_normals = normals;
+    m_hasSourceNormals = hasNormals && normals.size() == positions.size();
+
+    if (!m_hasSourceNormals) {
+        computeSmoothNormals();
+    } else {
+        if (m_normals.size() != m_positions.size())
+            m_normals = QVector<QVector3D>(m_positions.size(), QVector3D(0.0f, 1.0f, 0.0f));
+    }
+
+    updateBounds();
+    m_uploaded = false;
+}
+
+void Mesh::updateBounds()
+{
+    if (m_positions.isEmpty()) {
+        m_minBounds = QVector3D();
+        m_maxBounds = QVector3D();
+        return;
+    }
+
+    m_minBounds = m_positions.first();
+    m_maxBounds = m_positions.first();
+    for (const QVector3D &p : m_positions) {
+        m_minBounds.setX(qMin(m_minBounds.x(), p.x()));
+        m_minBounds.setY(qMin(m_minBounds.y(), p.y()));
+        m_minBounds.setZ(qMin(m_minBounds.z(), p.z()));
+        m_maxBounds.setX(qMax(m_maxBounds.x(), p.x()));
+        m_maxBounds.setY(qMax(m_maxBounds.y(), p.y()));
+        m_maxBounds.setZ(qMax(m_maxBounds.z(), p.z()));
+    }
+}
+
+void Mesh::computeSmoothNormals()
+{
+    m_normals.resize(m_positions.size());
+    std::fill(m_normals.begin(), m_normals.end(), QVector3D());
+
+    for (int i = 0; i + 2 < m_indices.size(); i += 3) {
+        const unsigned int ia = m_indices.at(i);
+        const unsigned int ib = m_indices.at(i + 1);
+        const unsigned int ic = m_indices.at(i + 2);
+        if (ia >= static_cast<unsigned int>(m_positions.size()) ||
+            ib >= static_cast<unsigned int>(m_positions.size()) ||
+            ic >= static_cast<unsigned int>(m_positions.size()))
+            continue;
+
+        const QVector3D &a = m_positions.at(ia);
+        const QVector3D &b = m_positions.at(ib);
+        const QVector3D &c = m_positions.at(ic);
+        QVector3D n = QVector3D::crossProduct(b - a, c - a);
+        if (!n.isNull())
+            n.normalize();
+
+        m_normals[ia] += n;
+        m_normals[ib] += n;
+        m_normals[ic] += n;
+    }
+
+    for (QVector3D &n : m_normals) {
+        if (!n.isNull())
+            n.normalize();
+        else
+            n = QVector3D(0.0f, 1.0f, 0.0f);
+    }
+
+    m_uploaded = false;
+}
+
+void Mesh::restoreOriginalNormals()
+{
+    if (!m_originalNormals.isEmpty() && m_originalNormals.size() == m_positions.size()) {
+        m_normals = m_originalNormals;
+    } else if (m_normals.isEmpty()) {
+        computeSmoothNormals();
+    }
+    m_uploaded = false;
+}
+
+void Mesh::upload(QOpenGLFunctions_4_1_Core *gl)
+{
+    if (!gl || !isValid())
+        return;
+
+    if (m_normals.size() != m_positions.size())
+        computeSmoothNormals();
+
+    if (!m_vao.isCreated())
+        m_vao.create();
+    QOpenGLVertexArrayObject::Binder vaoBinder(&m_vao);
+
+    if (!m_vbo.isCreated())
+        m_vbo.create();
+    m_vbo.bind();
+    m_vbo.setUsagePattern(QOpenGLBuffer::StaticDraw);
+
+    struct Vertex
+    {
+        QVector3D position;
+        QVector3D normal;
+    };
+
+    QVector<Vertex> vertexData;
+    vertexData.resize(m_positions.size());
+    for (int i = 0; i < m_positions.size(); ++i) {
+        vertexData[i].position = m_positions.at(i);
+        vertexData[i].normal = (i < m_normals.size()) ? m_normals.at(i) : QVector3D(0, 1, 0);
+    }
+
+    m_vbo.allocate(vertexData.constData(), vertexData.size() * sizeof(Vertex));
+
+    if (!m_ebo.isCreated())
+        m_ebo.create();
+    m_ebo.bind();
+    m_ebo.setUsagePattern(QOpenGLBuffer::StaticDraw);
+    m_ebo.allocate(m_indices.constData(), m_indices.size() * sizeof(unsigned int));
+
+    gl->glEnableVertexAttribArray(0);
+    gl->glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), reinterpret_cast<void *>(offsetof(Vertex, position)));
+    gl->glEnableVertexAttribArray(1);
+    gl->glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), reinterpret_cast<void *>(offsetof(Vertex, normal)));
+
+    m_uploaded = true;
+}
+
+void Mesh::draw(QOpenGLFunctions_4_1_Core *gl) const
+{
+    if (!m_uploaded || !gl)
+        return;
+
+    QOpenGLVertexArrayObject::Binder vaoBinder(const_cast<QOpenGLVertexArrayObject *>(&m_vao));
+    gl->glDrawElements(GL_TRIANGLES, m_indices.size(), GL_UNSIGNED_INT, nullptr);
+}
+
+quint64 Mesh::triangleCount() const
+{
+    return static_cast<quint64>(m_indices.size()) / 3;
+}

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <QOpenGLBuffer>
+#include <QOpenGLFunctions_4_1_Core>
+#include <QOpenGLVertexArrayObject>
+#include <QVector>
+#include <QVector3D>
+
+class Mesh
+{
+public:
+    Mesh();
+    ~Mesh();
+
+    void clear();
+    bool isValid() const;
+
+    void setData(const QVector<QVector3D> &positions,
+                 const QVector<QVector3D> &normals,
+                 const QVector<unsigned int> &indices,
+                 bool hasNormals);
+
+    void upload(QOpenGLFunctions_4_1_Core *gl);
+    void draw(QOpenGLFunctions_4_1_Core *gl) const;
+
+    quint64 triangleCount() const;
+    const QVector3D &minBounds() const { return m_minBounds; }
+    const QVector3D &maxBounds() const { return m_maxBounds; }
+    QVector3D size() const { return m_maxBounds - m_minBounds; }
+
+    bool hasSourceNormals() const { return m_hasSourceNormals; }
+    void computeSmoothNormals();
+    void restoreOriginalNormals();
+
+    const QVector<QVector3D> &positions() const { return m_positions; }
+    const QVector<unsigned int> &indices() const { return m_indices; }
+    const QVector<QVector3D> &normals() const { return m_normals; }
+
+private:
+    void updateBounds();
+
+    QVector<QVector3D> m_positions;
+    QVector<unsigned int> m_indices;
+    QVector<QVector3D> m_normals;
+    QVector<QVector3D> m_originalNormals;
+
+    bool m_hasSourceNormals = false;
+    bool m_uploaded = false;
+
+    QVector3D m_minBounds;
+    QVector3D m_maxBounds;
+
+    QOpenGLBuffer m_vbo;
+    QOpenGLBuffer m_ebo;
+    QOpenGLVertexArrayObject m_vao;
+};

--- a/src/MeshLoader.cpp
+++ b/src/MeshLoader.cpp
@@ -1,0 +1,66 @@
+#include "MeshLoader.h"
+#include "STLParser.h"
+
+#ifdef USE_ASSIMP
+#include <assimp/Importer.hpp>
+#include <assimp/postprocess.h>
+#include <assimp/scene.h>
+#endif
+
+#include <QObject>
+
+MeshLoader::MeshLoader() = default;
+
+MeshBuffer MeshLoader::load(const QString &path, QString *errorMessage) const
+{
+#ifdef USE_ASSIMP
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(path.toStdString(),
+                                            aiProcess_Triangulate |
+                                                aiProcess_JoinIdenticalVertices |
+                                                aiProcess_GenNormals |
+                                                aiProcess_ImproveCacheLocality |
+                                                aiProcess_OptimizeMeshes);
+    if (scene && scene->HasMeshes()) {
+        MeshBuffer buffer;
+        bool allHaveNormals = true;
+        for (unsigned int meshIndex = 0; meshIndex < scene->mNumMeshes; ++meshIndex) {
+            const aiMesh *mesh = scene->mMeshes[meshIndex];
+            if (!mesh)
+                continue;
+            const unsigned int baseIndex = buffer.positions.size();
+            for (unsigned int i = 0; i < mesh->mNumVertices; ++i) {
+                const aiVector3D &v = mesh->mVertices[i];
+                buffer.positions.append(QVector3D(v.x, v.y, v.z));
+                if (mesh->HasNormals()) {
+                    const aiVector3D &n = mesh->mNormals[i];
+                    buffer.normals.append(QVector3D(n.x, n.y, n.z));
+                }
+            }
+            if (!mesh->HasNormals())
+                allHaveNormals = false;
+
+            for (unsigned int f = 0; f < mesh->mNumFaces; ++f) {
+                const aiFace &face = mesh->mFaces[f];
+                if (face.mNumIndices < 3)
+                    continue;
+                for (unsigned int idx = 0; idx < 3; ++idx)
+                    buffer.indices.append(baseIndex + face.mIndices[idx]);
+            }
+        }
+        if (!allHaveNormals)
+            buffer.normals.clear();
+        buffer.hasNormals = allHaveNormals && !buffer.normals.isEmpty();
+        if (!buffer.positions.isEmpty())
+            return buffer;
+        if (errorMessage)
+            *errorMessage = QObject::tr("Assimp imported scene without vertices.");
+    } else {
+        if (errorMessage)
+            *errorMessage = QObject::tr("Assimp error: %1").arg(QString::fromLocal8Bit(importer.GetErrorString()));
+    }
+#endif
+
+    STLParser parser;
+    return parser.parse(path, errorMessage);
+}

--- a/src/MeshLoader.h
+++ b/src/MeshLoader.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QString>
+#include <QVector>
+#include <QVector3D>
+
+struct MeshBuffer
+{
+    QVector<QVector3D> positions;
+    QVector<QVector3D> normals;
+    QVector<unsigned int> indices;
+    bool hasNormals = false;
+};
+
+class MeshLoader
+{
+public:
+    MeshLoader();
+    MeshBuffer load(const QString &path, QString *errorMessage) const;
+};

--- a/src/MeshStatistics.h
+++ b/src/MeshStatistics.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <QVector3D>
+#include <QString>
+
+struct MeshStatistics
+{
+    QString fileName;
+    quint64 triangleCount = 0;
+    QVector3D minBounds;
+    QVector3D maxBounds;
+    QVector3D size;
+    bool hasNormals = false;
+};

--- a/src/STLParser.cpp
+++ b/src/STLParser.cpp
@@ -1,0 +1,154 @@
+#include "STLParser.h"
+
+#include <QByteArray>
+#include <QDataStream>
+#include <QFile>
+#include <QIODevice>
+#include <QRegularExpression>
+#include <QString>
+#include <QStringList>
+#include <QTextStream>
+#include <QObject>
+#include <QVector>
+
+MeshBuffer STLParser::parse(const QString &path, QString *errorMessage) const
+{
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        if (errorMessage)
+            *errorMessage = QObject::tr("Unable to open file %1").arg(path);
+        return {};
+    }
+
+    QByteArray header = file.peek(512);
+    const bool headerLooksAscii = header.trimmed().startsWith("solid");
+    const bool containsNull = header.contains('\0');
+
+    file.seek(0);
+    if (headerLooksAscii && !containsNull) {
+        return parseAscii(file, errorMessage);
+    }
+
+    file.seek(0);
+    return parseBinary(file, errorMessage);
+}
+
+MeshBuffer STLParser::parseAscii(QIODevice &device, QString *errorMessage) const
+{
+    MeshBuffer buffer;
+    QTextStream stream(&device);
+    stream.setCodec("UTF-8");
+
+    QVector<QVector3D> facetVertices;
+    facetVertices.reserve(3);
+    QVector3D facetNormal(0, 1, 0);
+
+    while (!stream.atEnd()) {
+        QString line = stream.readLine().trimmed();
+        if (line.startsWith(QLatin1String("facet"), Qt::CaseInsensitive)) {
+            QStringList parts = line.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
+            if (parts.size() >= 5) {
+                facetNormal = QVector3D(parts.at(2).toFloat(), parts.at(3).toFloat(), parts.at(4).toFloat());
+                if (!facetNormal.isNull())
+                    facetNormal.normalize();
+            }
+        } else if (line.startsWith(QLatin1String("vertex"), Qt::CaseInsensitive)) {
+            QStringList parts = line.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
+            if (parts.size() >= 4) {
+                QVector3D v(parts.at(1).toFloat(), parts.at(2).toFloat(), parts.at(3).toFloat());
+                facetVertices.append(v);
+            }
+        } else if (line.startsWith(QLatin1String("endfacet"), Qt::CaseInsensitive)) {
+            if (facetVertices.size() == 3) {
+                const unsigned int baseIndex = buffer.positions.size();
+                for (int i = 0; i < 3; ++i) {
+                    buffer.positions.append(facetVertices.at(i));
+                    buffer.normals.append(facetNormal);
+                    buffer.indices.append(baseIndex + i);
+                }
+            }
+            facetVertices.clear();
+        }
+    }
+
+    buffer.hasNormals = !buffer.normals.isEmpty();
+
+    if (buffer.positions.isEmpty() && errorMessage)
+        *errorMessage = QObject::tr("No geometry found in STL file.");
+
+    return buffer;
+}
+
+MeshBuffer STLParser::parseBinary(QIODevice &device, QString *errorMessage) const
+{
+    MeshBuffer buffer;
+    if (!device.isOpen()) {
+        if (!device.open(QIODevice::ReadOnly)) {
+            if (errorMessage)
+                *errorMessage = QObject::tr("Unable to read STL stream.");
+            return buffer;
+        }
+    }
+
+    if (!device.seek(80)) {
+        if (errorMessage)
+            *errorMessage = QObject::tr("Invalid STL header.");
+        return buffer;
+    }
+
+    QDataStream stream(&device);
+    stream.setByteOrder(QDataStream::LittleEndian);
+
+    quint32 triangleCount = 0;
+    stream >> triangleCount;
+    if (stream.status() != QDataStream::Ok) {
+        if (errorMessage)
+            *errorMessage = QObject::tr("Unable to read triangle count.");
+        return buffer;
+    }
+
+    buffer.positions.reserve(triangleCount * 3);
+    buffer.normals.reserve(triangleCount * 3);
+    buffer.indices.reserve(triangleCount * 3);
+
+    for (quint32 i = 0; i < triangleCount; ++i) {
+        float nx, ny, nz;
+        float ax, ay, az;
+        float bx, by, bz;
+        float cx, cy, cz;
+        quint16 attribute = 0;
+
+        stream >> nx >> ny >> nz;
+        stream >> ax >> ay >> az;
+        stream >> bx >> by >> bz;
+        stream >> cx >> cy >> cz;
+        stream >> attribute;
+
+        if (stream.status() != QDataStream::Ok) {
+            if (errorMessage)
+                *errorMessage = QObject::tr("Unexpected end of STL file.");
+            buffer.positions.clear();
+            buffer.normals.clear();
+            buffer.indices.clear();
+            return buffer;
+        }
+
+        QVector3D normal(nx, ny, nz);
+        if (!normal.isNull())
+            normal.normalize();
+        const unsigned int baseIndex = buffer.positions.size();
+        const QVector3D vertices[3] = {
+            QVector3D(ax, ay, az),
+            QVector3D(bx, by, bz),
+            QVector3D(cx, cy, cz)};
+        for (int v = 0; v < 3; ++v) {
+            buffer.positions.append(vertices[v]);
+            buffer.normals.append(normal);
+            buffer.indices.append(baseIndex + v);
+        }
+        Q_UNUSED(attribute);
+    }
+
+    buffer.hasNormals = !buffer.normals.isEmpty();
+    return buffer;
+}

--- a/src/STLParser.h
+++ b/src/STLParser.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "MeshLoader.h"
+
+class STLParser
+{
+public:
+    STLParser() = default;
+    MeshBuffer parse(const QString &path, QString *errorMessage) const;
+
+private:
+    MeshBuffer parseAscii(QIODevice &device, QString *errorMessage) const;
+    MeshBuffer parseBinary(QIODevice &device, QString *errorMessage) const;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,27 @@
+#include "MainWindow.h"
+
+#include <QApplication>
+#include <QSurfaceFormat>
+
+int main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+    QApplication::setOrganizationName("OpenAI");
+    QApplication::setOrganizationDomain("openai.com");
+    QApplication::setApplicationName("STL Viewer");
+
+    QSurfaceFormat format;
+    format.setRenderableType(QSurfaceFormat::OpenGL);
+    format.setProfile(QSurfaceFormat::CoreProfile);
+    format.setVersion(4, 1);
+    format.setDepthBufferSize(24);
+    format.setStencilBufferSize(8);
+    format.setSamples(4);
+    format.setColorSpace(QSurfaceFormat::sRGBColorSpace);
+    QSurfaceFormat::setDefaultFormat(format);
+
+    MainWindow window;
+    window.show();
+
+    return app.exec();
+}


### PR DESCRIPTION
## Summary
- implement a Qt6/QOpenGLWidget viewport with shaded, wireframe, and hybrid rendering plus camera orbit, fly navigation, bounding boxes, and screenshots
- add a dock-based control panel for model metadata, render toggles, persistent settings, and per-axis transforms with recent file management
- integrate STL loading via Assimp when available with a fallback parser, mesh utilities, documentation, and sample assets
- remove the redundant tetra binary STL sample asset per follow-up review

## Testing
- cmake -S . -B build *(fails: Qt6 development packages are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e55162834c832a9cef1230c04f7e32